### PR TITLE
Remove floating point noise and make doctests pass again

### DIFF
--- a/tests/objects.txt
+++ b/tests/objects.txt
@@ -60,7 +60,7 @@ Encoding objects with __geo_interface__
 
   >>> feature_dict = geojson.loads(json)
   >>> geojson.dumps(feature_dict, sort_keys=True)  # doctest: +ELLIPSIS
-  '{"geometry": {"coordinates": [4.5324200000000001, -54.123100000000001], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}'
+  '{"geometry": {"coordinates": [4.53242, -54.1231], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}'
 
   - or to an object, via a factory. Here we'll create GeoJSON object.
 


### PR DESCRIPTION
Doctests currently fail with both Python 2.7.5 and PyPy 2.0.2 (see below).

``` pytb
[steko@ogma geojson]$ python setup.py test
running test
running egg_info
writing requirements to geojson.egg-info/requires.txt
writing geojson.egg-info/PKG-INFO
writing top-level names to geojson.egg-info/top_level.txt
writing dependency_links to geojson.egg-info/dependency_links.txt
writing requirements to geojson.egg-info/requires.txt
writing geojson.egg-info/PKG-INFO
writing top-level names to geojson.egg-info/top_level.txt
writing dependency_links to geojson.egg-info/dependency_links.txt
reading manifest file 'geojson.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'geojson.egg-info/SOURCES.txt'
running build_ext
/home/steko/code/geojson/tests/featurecollection.txt
Doctest: featurecollection.txt ... ok
/home/steko/code/geojson/tests/geometry.txt
Doctest: geometry.txt ... ok
/home/steko/code/geojson/tests/fallsthrough_to_json.txt
Doctest: fallsthrough_to_json.txt ... ok
/home/steko/code/geojson/tests/c2c_features.txt
Doctest: c2c_features.txt ... ok
/home/steko/code/geojson/tests/feature-null-geom.txt
Doctest: feature-null-geom.txt ... ok
/home/steko/code/geojson/tests/README.txt
Doctest: README.txt ... ok
/home/steko/code/geojson/tests/crs.txt
Doctest: crs.txt ... ok
/home/steko/code/geojson/tests/including_additional_members.txt
Doctest: including_additional_members.txt ... ok
/home/steko/code/geojson/tests/features.txt
Doctest: features.txt ... ok
/home/steko/code/geojson/tests/geometrycollection.txt
Doctest: geometrycollection.txt ... ok
/home/steko/code/geojson/tests/blog.txt
Doctest: blog.txt ... ok
/home/steko/code/geojson/tests/strict_json.txt
Doctest: strict_json.txt ... ok
/home/steko/code/geojson/tests/objects.txt
Doctest: objects.txt ... FAIL

======================================================================
FAIL: /home/steko/code/geojson/tests/objects.txt
Doctest: objects.txt
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python2.7/doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for objects.txt
  File "/home/steko/code/geojson/tests/objects.txt", line 0

----------------------------------------------------------------------
File "/home/steko/code/geojson/tests/objects.txt", line 62, in objects.txt
Failed example:
    geojson.dumps(feature_dict, sort_keys=True)  # doctest: +ELLIPSIS
Expected:
    '{"geometry": {"coordinates": [4.5324200000000001, -54.123100000000001], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}'
Got:
    '{"geometry": {"coordinates": [4.53242, -54.1231], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}'


----------------------------------------------------------------------
Ran 13 tests in 0.033s

FAILED (failures=1)
```

``` pytb
[steko@ogma geojson]$ pypy setup.py test
running test
Searching for nose>=0.11
Reading https://pypi.python.org/simple/nose/
Best match: nose 1.3.0
Downloading https://pypi.python.org/packages/source/n/nose/nose-1.3.0.tar.gz#md5=95d6d32b9d6b029c3c65674bd9e7eabe
Processing nose-1.3.0.tar.gz
Writing /var/tmp/easy_install-uw8_v7/nose-1.3.0/setup.cfg
Running nose-1.3.0/setup.py -q bdist_egg --dist-dir /var/tmp/easy_install-uw8_v7/nose-1.3.0/egg-dist-tmp-VeGMlY
no previously-included directories found matching 'doc/.build'

Installed /home/steko/code/geojson/nose-1.3.0-py2.7.egg
running egg_info
creating geojson.egg-info
writing requirements to geojson.egg-info/requires.txt
writing geojson.egg-info/PKG-INFO
writing top-level names to geojson.egg-info/top_level.txt
writing dependency_links to geojson.egg-info/dependency_links.txt
writing manifest file 'geojson.egg-info/SOURCES.txt'
reading manifest file 'geojson.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'geojson.egg-info/SOURCES.txt'
running build_ext
/home/steko/code/geojson/tests/featurecollection.txt
Doctest: featurecollection.txt ... ok
/home/steko/code/geojson/tests/geometry.txt
Doctest: geometry.txt ... ok
/home/steko/code/geojson/tests/fallsthrough_to_json.txt
Doctest: fallsthrough_to_json.txt ... ok
/home/steko/code/geojson/tests/c2c_features.txt
Doctest: c2c_features.txt ... ok
/home/steko/code/geojson/tests/feature-null-geom.txt
Doctest: feature-null-geom.txt ... ok
/home/steko/code/geojson/tests/README.txt
Doctest: README.txt ... ok
/home/steko/code/geojson/tests/crs.txt
Doctest: crs.txt ... ok
/home/steko/code/geojson/tests/including_additional_members.txt
Doctest: including_additional_members.txt ... ok
/home/steko/code/geojson/tests/features.txt
Doctest: features.txt ... ok
/home/steko/code/geojson/tests/geometrycollection.txt
Doctest: geometrycollection.txt ... ok
/home/steko/code/geojson/tests/blog.txt
Doctest: blog.txt ... ok
/home/steko/code/geojson/tests/strict_json.txt
Doctest: strict_json.txt ... ok
/home/steko/code/geojson/tests/objects.txt
Doctest: objects.txt ... FAIL

======================================================================
FAIL: /home/steko/code/geojson/tests/objects.txt
Doctest: objects.txt
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/pypy-2.0.2/lib-python/2.7/doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for objects.txt
  File "/home/steko/code/geojson/tests/objects.txt", line 0

----------------------------------------------------------------------
File "/home/steko/code/geojson/tests/objects.txt", line 62, in objects.txt
Failed example:
    geojson.dumps(feature_dict, sort_keys=True)  # doctest: +ELLIPSIS
Expected:
    '{"geometry": {"coordinates": [4.5324200000000001, -54.123100000000001], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}'
Got:
    '{"geometry": {"coordinates": [4.53242, -54.1231], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}'


----------------------------------------------------------------------
Ran 13 tests in 0.260s

FAILED (failures=1)
```
