### PR TITLE
Add coords() and map_coords() utils.

### DIFF
--- a/geojson/__init__.py
+++ b/geojson/__init__.py
@@ -1,4 +1,5 @@
 from geojson.codec import dump, dumps, load, loads, GeoJSONEncoder
+from geojson.coords import coords, map_coords
 from geojson.geometry import Point, LineString, Polygon
 from geojson.geometry import MultiLineString, MultiPoint, MultiPolygon
 from geojson.geometry import GeometryCollection

--- a/geojson/coords.py
+++ b/geojson/coords.py
@@ -1,0 +1,36 @@
+"""Coordinate utility functions."""
+
+def coords(obj):
+    """Yield all coordinate coordinate tuples from a geometry or feature."""
+    if isinstance(obj, (tuple, list)):
+        coordinates = obj
+    elif obj.has_key('geometry'):
+        coordinates = obj['geometry']['coordinates']
+    else:
+        coordinates = obj.get('coordinates', obj)
+    for e in coordinates:
+        if isinstance(e, (float, int)):
+            yield tuple(coordinates)
+            break
+        else:
+            for f in coords(e):
+                yield f
+
+def map_coords(func, obj):
+    """Return coordinates, mapped pair-wise using the provided function."""
+    if obj['type'] == 'Point':
+        coordinates = tuple(map(func, obj['coordinates']))
+    elif obj['type'] in ['LineString', 'MultiPoint']:
+        coordinates = [tuple(map(func, c)) for c in obj['coordinates']]
+    elif obj['type'] in ['MultiLineString', 'Polygon']:
+        coordinates = [[
+            tuple(map(func, c)) for c in curve]
+                for curve in obj['coordinates']]
+    elif obj['type'] == 'MultiPolygon':
+        coordinates = [[[
+            tuple(map(func, c)) for c in curve]
+                for curve in part]
+                    for part in obj['coordinates']]
+    else:
+        raise ValueError("Invalid geometry object %s" % repr(obj))
+    return {'type': obj['type'], 'coordinates': coordinates}

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,0 +1,55 @@
+
+import geojson
+from geojson.coords import coords, map_coords
+
+def test_point():
+    itr = coords(geojson.Point((-115.81, 37.24)))
+    assert next(itr) == (-115.81, 37.24)
+
+def test_dict():
+    itr = coords({'type': 'Point', 'coordinates': [-115.81, 37.24]})
+    assert next(itr) == (-115.81, 37.24)
+
+def test_point_feature():
+    itr = coords(geojson.Feature(geometry=geojson.Point((-115.81, 37.24))))
+    assert next(itr) == (-115.81, 37.24)
+
+def test_multipolygon():
+    g = geojson.MultiPolygon([
+        ([(3.78, 9.28), (-130.91, 1.52), (35.12, 72.234), (3.78, 9.28)],),
+        ([(23.18, -34.29), (-1.31, -4.61), (3.41, 77.91), (23.18, -34.29)],)])
+    itr = coords(g)
+    pairs = list(itr)
+    assert pairs[0] == (3.78, 9.28)
+    assert pairs[-1] == (23.18, -34.29)
+
+def test_map_point():
+    result = map_coords(lambda x: x, geojson.Point((-115.81, 37.24)))
+    assert result['type'] == 'Point'
+    assert result['coordinates'] == (-115.81, 37.24)
+
+def test_map_linestring():
+    g = geojson.LineString(
+        [(3.78, 9.28), (-130.91, 1.52), (35.12, 72.234), (3.78, 9.28)])
+    result = map_coords(lambda x: x, g)
+    assert result['type'] == 'LineString'
+    assert result['coordinates'][0] == (3.78, 9.28)
+    assert result['coordinates'][-1] == (3.78, 9.28)
+
+def test_map_polygon():
+    g = geojson.Polygon([
+        [(3.78, 9.28), (-130.91, 1.52), (35.12, 72.234), (3.78, 9.28)],])
+    result = map_coords(lambda x: x, g)
+    assert result['type'] == 'Polygon'
+    assert result['coordinates'][0][0] == (3.78, 9.28)
+    assert result['coordinates'][0][-1] == (3.78, 9.28)
+
+def test_map_multipolygon():
+    g = geojson.MultiPolygon([
+        ([(3.78, 9.28), (-130.91, 1.52), (35.12, 72.234), (3.78, 9.28)],),
+        ([(23.18, -34.29), (-1.31, -4.61), (3.41, 77.91), (23.18, -34.29)],)])
+    result = map_coords(lambda x: x, g)
+    assert result['type'] == 'MultiPolygon'
+    assert result['coordinates'][0][0][0] == (3.78, 9.28)
+    assert result['coordinates'][-1][-1][-1] == (23.18, -34.29)
+


### PR DESCRIPTION
Coords() yields all coordinate tuples from a geometry or
feature object.

Map_coords() maps a function over all coordinate tuples and returns
a geometry of the same type. Useful for translating a geometry in
space or flipping coordinate order.

I've rewritten functions like these a number of times and hope you'll
agree that python-geojson would be a good home for them. The tests
are for pytest, which I'm loving these days (I've converted Fiona and
Rasterio to pytest, am converting Shapely as I go).
