### PR TITLE
Use shields.io for README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 python-geojson
 ==============
 
-.. image:: https://travis-ci.org/frewsxcv/python-geojson.svg?branch=master
+.. image:: https://img.shields.io/travis/frewsxcv/python-geojson.svg
    :target: https://travis-ci.org/frewsxcv/python-geojson
-.. image:: https://codecov.io/github/frewsxcv/python-geojson/coverage.svg?branch=master
+.. image:: https://img.shields.io/codecov/c/github/frewsxcv/python-geojson.svg
    :target: https://codecov.io/github/frewsxcv/python-geojson?branch=master
 
 This library contains:


### PR DESCRIPTION
No real changes, just makes the badges visually consistent.

This uses the third-party [shields.io](http://shields.io/) service.
