### PR TITLE
Add include directive for Sphinx docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst


### PR DESCRIPTION
This PR uses a reST include directive in attempts of facilitating autogenerated ReadTheDocs docs while maintaining the rendered README on the GitHub repo homepage.