### PR TITLE
Remove 6-decimal-place rounding

### DIFF
--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -16,7 +16,7 @@ class Geometry(GeoJSON):
     Represents an abstract base class for a WGS84 geometry.
     """
 
-    def __init__(self, coordinates=None, validate=False, precision=6, **extra):
+    def __init__(self, coordinates=None, validate=False, precision, **extra):
         """
         Initialises a Geometry object.
 


### PR DESCRIPTION
When the `precision` param for geometry objects was added in 2.5.0, it had a "default precision" of 6 decimal places. This caused interoperability issues in some use cases. 

This removes the "default precision" while leaving the `precision` param in place with no default.

Resolves #135. 