### PR TITLE
Improve point validation

### DIFF
--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -86,7 +86,8 @@ def check_point(coord):
         return 'a position must have exactly 2 or 3 values'
     for number in coord:
         if not isinstance(number, Number):
-               return 'a position cannot have inner positions'
+            return 'a position cannot have inner positions'
+
 
 class Point(Geometry):
     def errors(self):

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -1,5 +1,6 @@
 import sys
 from decimal import Decimal
+from numbers import Number
 
 from geojson.base import GeoJSON
 
@@ -83,7 +84,9 @@ def check_point(coord):
         return 'each position must be a list'
     if len(coord) not in (2, 3):
         return 'a position must have exactly 2 or 3 values'
-
+    for number in coord:
+        if not isinstance(number, Number):
+               return 'a position cannot have inner positions'
 
 class Point(Geometry):
     def errors(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -54,6 +54,9 @@ class TestValidationPoint(unittest.TestCase):
         point = geojson.Point((10, 20, 30, 40))
         self.assertEqual(point.is_valid, False)
 
+        point = geojson.Point([(10,20), (30,40)])
+        self.assertEqual(point.is_valid, False)
+
     def test_valid_point(self):
         point = geojson.Point((-3.68, 40.41))
         self.assertEqual(point.is_valid, True)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -54,7 +54,7 @@ class TestValidationPoint(unittest.TestCase):
         point = geojson.Point((10, 20, 30, 40))
         self.assertEqual(point.is_valid, False)
 
-        point = geojson.Point([(10,20), (30,40)])
+        point = geojson.Point([(10, 20), (30, 40)])
         self.assertEqual(point.is_valid, False)
 
     def test_valid_point(self):


### PR DESCRIPTION
When you initialize a point using coordinates for a line, it says is a valid point:

```
import geojson

lineCoords=[[1,2],[3,4]]
pointCoords=[5,6]

print ("Line(lineCoords): ", geojson.LineString(lineCoords).is_valid)
print ("Line(pointCoors): ", geojson.LineString(pointCoords).is_valid)
print ("Point(pointCoords): ", geojson.Point(pointCoords).is_valid)
print ("Point(lineCoords): ", geojson.Point(lineCoords).is_valid)
```

Which produces the next exit:

> Line(lineCoords):  True
> Line(pointCoors):  False
> Point(pointCoords):  True
> Point(lineCoords):  True

The reason behind this, is because the position array is only validating it's length, but not the format.

I think this pull request solves the problem