### PR TITLE
Update tox config to drop Python 2.7 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35,36,37}, pypy, pypy3
+envlist = py{36,37,38}, pypy3
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
This tiny update will allow `tox` to test only the currently supported Python versions.