### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ This Python library contains:
 Installation
 ------------
 
-geojson is compatible with Python 3.6, 3.7 and 3.8. The recommended way to install is via pip_:
+geojson is compatible with Python 3.6 - 3.9. The recommended way to install is via pip_:
 
 .. code::
 

--- a/geojson/base.py
+++ b/geojson/base.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import geojson
 from geojson.mapping import to_mapping
 
@@ -19,7 +17,7 @@ class GeoJSON(dict):
         :return: a GeoJSON object
         :rtype: GeoJSON
         """
-        super(GeoJSON, self).__init__(iterable)
+        super().__init__(iterable)
         self["type"] = getattr(self, "type", type(self).__name__)
         self.update(extra)
 

--- a/geojson/examples.py
+++ b/geojson/examples.py
@@ -1,5 +1,4 @@
-
-class SimpleWebFeature(object):
+class SimpleWebFeature:
 
     """
     A simple, Atom-ish, single geometry (WGS84) GIS feature.

--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -23,7 +23,7 @@ class Feature(GeoJSON):
         :return: Feature object
         :rtype: Feature
         """
-        super(Feature, self).__init__(**extra)
+        super().__init__(**extra)
         if id is not None:
             self["id"] = id
         self["geometry"] = (self.to_instance(geometry, strict=True)
@@ -48,7 +48,7 @@ class FeatureCollection(GeoJSON):
         :return: FeatureCollection object
         :rtype: FeatureCollection
         """
-        super(FeatureCollection, self).__init__(**extra)
+        super().__init__(**extra)
         self["features"] = features
 
     def errors(self):

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -28,14 +28,14 @@ class Geometry(GeoJSON):
         :param precision: Number of decimal places for lat/lon coords.
         :type precision: integer
         """
-        super(Geometry, self).__init__(**extra)
+        super().__init__(**extra)
         self["coordinates"] = self.clean_coordinates(
             coordinates or [], precision)
 
         if validate:
             errors = self.errors()
             if errors:
-                raise ValueError('{}: {}'.format(errors, coordinates))
+                raise ValueError(f'{errors}: {coordinates}')
 
     @classmethod
     def clean_coordinates(cls, coords, precision):
@@ -63,7 +63,7 @@ class GeometryCollection(GeoJSON):
     """
 
     def __init__(self, geometries=None, **extra):
-        super(GeometryCollection, self).__init__(**extra)
+        super().__init__(**extra)
         self["geometries"] = geometries or []
 
     def errors(self):
@@ -147,7 +147,7 @@ class MultiPolygon(Geometry):
         return self.check_list_errors(check_polygon, self['coordinates'])
 
 
-class Default(object):
+class Default:
     """
     GeoJSON default object.
     """

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -1,15 +1,7 @@
-import sys
 from decimal import Decimal
 from numbers import Number
 
 from geojson.base import GeoJSON
-
-
-if sys.version_info[0] == 3:
-    # Python 3.x has no long type
-    _JSON_compliant_types = (float, int, Decimal)
-else:
-    _JSON_compliant_types = (float, int, Decimal, long)  # noqa
 
 
 class Geometry(GeoJSON):
@@ -50,7 +42,7 @@ class Geometry(GeoJSON):
                 new_coords.append(cls.clean_coordinates(coord, precision))
             elif isinstance(coord, Geometry):
                 new_coords.append(coord['coordinates'])
-            elif isinstance(coord, _JSON_compliant_types):
+            elif isinstance(coord, (float, int, Decimal)):
                 new_coords.append(round(coord, precision))
             else:
                 raise ValueError("%r is not a JSON compliant number" % coord)

--- a/geojson/mapping.py
+++ b/geojson/mapping.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 
 try:
     import simplejson as json

--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -15,15 +15,12 @@ def coords(obj):
         for f in obj['features']:
             # For Python 2 compatibility
             # See https://www.reddit.com/r/learnpython/comments/4rc15s/yield_from_and_python_27/ # noqa: E501
-            for c in coords(f):
-                yield c
+            yield from coords(f)
     elif 'geometry' in obj:  # Feature
-        for c in coords(obj['geometry']):
-            yield c
+        yield from coords(obj['geometry'])
     elif 'geometries' in obj:  # GeometryCollection
         for g in obj['geometries']:
-            for c in coords(g):
-                yield c
+            yield from coords(g)
     else:
         if isinstance(obj, (tuple, list)):
             coordinates = obj

--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -13,8 +13,6 @@ def coords(obj):
     # Handle recursive case first
     if 'features' in obj:  # FeatureCollection
         for f in obj['features']:
-            # For Python 2 compatibility
-            # See https://www.reddit.com/r/learnpython/comments/4rc15s/yield_from_and_python_27/ # noqa: E501
             yield from coords(f)
     elif 'geometry' in obj:  # Feature
         yield from coords(obj['geometry'])

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,17 @@ import sys
 import re
 
 
-with io.open("README.rst") as readme_file:
+with open("README.rst") as readme_file:
     readme_text = readme_file.read()
 
 VERSIONFILE = "geojson/_version.py"
-verstrline = open(VERSIONFILE, "rt").read()
+verstrline = open(VERSIONFILE).read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)
 if mo:
     verstr = mo.group(1)
 else:
-    raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+    raise RuntimeError(f"Unable to find version string in {VERSIONFILE}.")
 
 
 def test_suite():

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import io
 from setuptools import setup
 import sys
 import re
@@ -19,10 +18,7 @@ else:
 
 def test_suite():
     import doctest
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        import unittest
+    import unittest
 
     suite = unittest.TestLoader().discover("tests")
     suite.addTest(doctest.DocFileSuite("README.rst"))

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ def test_suite():
 
 
 major_version, minor_version = sys.version_info[:2]
-if not (major_version == 3 and 6 <= minor_version <= 8):
-    sys.stderr.write("Sorry, only Python 3.6, 3.7 and 3.8 are "
+if not (major_version == 3 and 6 <= minor_version <= 9):
+    sys.stderr.write("Sorry, only Python 3.6 - 3.9 are "
                      "supported at this time.\n")
     exit(1)
 
@@ -52,6 +52,7 @@ setup(
     package_data={"geojson": ["*.rst"]},
     install_requires=[],
     test_suite="setup.test_suite",
+    python_requires=">=3.6, <=3.9",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -63,6 +64,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: GIS",
     ]
 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for geojson/base.py
 """

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for geojson object constructor
 """

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -52,12 +52,12 @@ class CoordsTestCase(unittest.TestCase):
               (3.41, 77.91), (23.18, -34.29)],)])
         itr = coords(geojson.GeometryCollection([p1, p2, ln, g]))
         pairs = set(itr)
-        self.assertEqual(pairs, set([
+        self.assertEqual(pairs, {
             (-115.11, 37.11), (-115.22, 37.22),
             (-115.3, 37.3), (-115.4, 37.4), (-115.5, 37.5),
             (3.78, 9.28), (-130.91, 1.52), (35.12, 72.234), (3.78, 9.28),
             (23.18, -34.29), (-1.31, -4.61), (3.41, 77.91), (23.18, -34.29)
-        ]))
+        })
 
     def test_map_point(self):
         result = map_coords(lambda x: x, geojson.Point((-115.81, 37.24)))

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -94,7 +94,7 @@ class FeaturesTest(unittest.TestCase):
                          '{"coordinates": [53.0, -4.0], "type": "Point"}')
 
     def test_geo_interface(self):
-        class Thingy(object):
+        class Thingy:
             def __init__(self, id, title, x, y):
                 self.id = id
                 self.title = title

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,7 +1,4 @@
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import unittest
 
 import geojson

--- a/tests/test_geo_interface.py
+++ b/tests/test_geo_interface.py
@@ -10,12 +10,12 @@ from geojson.mapping import to_mapping
 class EncodingDecodingTest(unittest.TestCase):
 
     def setUp(self):
-        class Restaurant(object):
+        class Restaurant:
             """
             Basic Restaurant class
             """
             def __init__(self, name, latlng):
-                super(Restaurant, self).__init__()
+                super().__init__()
                 self.name = name
                 self.latlng = latlng
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for geojson/validation
 """

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38}, pypy3
+envlist = py{36,37,38,39}, pypy3
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
Adds testing and the Trove classifier for Python 3.9, which came out last month.

Also upgrades Python syntax with https://github.com/asottile/pyupgrade `--py36-plus` and removes some redundant Python 2 code.

This also adds:
```python
python_requires=">=3.6, <=3.9",
```

Which helps pip only install for those versions, so perhaps this could be removed from `setup.py`?

```python
if not (major_version == 3 and 6 <= minor_version <= 9):
    sys.stderr.write("Sorry, only Python 3.6 - 3.9 are "
                     "supported at this time.\n")
    exit(1)
```

I'd also suggest removing the upper limit too; when Python 3.10 comes out next October, it'll _probably_ work, and people won't need to wait for a new release of geojson.
