### PR TITLE
Add list method aliases to FeatureCollection

### DIFF
--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -59,3 +59,23 @@ class FeatureCollection(GeoJSON):
             return self.get("features", ())[key]
         except (KeyError, TypeError, IndexError):
             return super(GeoJSON, self).__getitem__(key)
+
+    def __add__(self, other):
+        copy = self.copy()
+        copy["features"] += other
+        return copy
+
+    def __radd__(self, other):
+        return other + self["features"]
+
+    def clear(self) -> None:
+        self["features"].clear()
+
+    def append(self, x):
+        self["features"].append(x)
+
+    def extend(self, iterable):
+        self["features"].extend(iterable)
+
+    def insert(self, i, x):
+        self["features"].insert(i, x)

--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -68,9 +68,6 @@ class FeatureCollection(GeoJSON):
     def __radd__(self, other):
         return other + self["features"]
 
-    def clear(self) -> None:
-        self["features"].clear()
-
     def append(self, x):
         self["features"].append(x)
 

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -1,0 +1,88 @@
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+import unittest
+
+from geojson.feature import Feature, FeatureCollection
+
+
+class FeatureCollectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.feature1 = Feature(
+            id="1",
+            geometry={"type": "Point", "coordinates": [53.0, -4.0]},
+            properties={
+                "title": "Feature 1",
+                "summary": "The first feature",
+                "link": "http://example.org/features/1",
+            },
+        )
+        self.feature2 = Feature(
+            id="1",
+            geometry={"type": "Point", "coordinates": [54.0, -3.0]},
+            properties={
+                "title": "Feature 2",
+                "summary": "The second feature",
+                "link": "http://example.org/features/2",
+            },
+        )
+
+    def test_feature_collection_add(self):
+        fc1 = FeatureCollection([self.feature1])
+        fc2 = FeatureCollection([self.feature2])
+
+        fc3 = fc1 + fc2
+
+        assert len(fc1["features"]) == 1
+        assert len(fc2["features"]) == 1
+        assert len(fc3["features"]) == 2
+        assert fc3["features"][0] == self.feature1
+        assert fc3["features"][1] == self.feature2
+
+    def test_feature_collection_radd(self):
+        fc = FeatureCollection([self.feature1, self.feature2])
+
+        list1 = [] + fc
+
+        assert len(list1) == 2
+        assert isinstance(list1, list)
+        assert list1[0] == self.feature1
+        assert list1[1] == self.feature2
+
+    def test_feature_collection_append(self):
+        fc = FeatureCollection([self.feature1])
+
+        fc.append(self.feature2)
+
+        assert len(fc["features"]) == 2
+        assert fc["features"][0] == self.feature1
+        assert fc["features"][1] == self.feature2
+
+    def test_feature_collection_clear(self):
+        fc = FeatureCollection([self.feature1, self.feature2])
+
+        fc.clear()
+
+        assert not fc["features"]
+
+    def test_feature_collection_extend(self):
+        fc1 = FeatureCollection([self.feature1])
+        fc2 = FeatureCollection([self.feature2])
+
+        fc3 = fc1 + fc2
+
+        assert len(fc3["features"]) == 2
+        assert len(fc1["features"]) == 1
+        assert len(fc2["features"]) == 1
+        assert fc3["features"][0] == self.feature1
+        assert fc3["features"][1] == self.feature2
+
+    def test_feature_collection_insert(self):
+        fc = FeatureCollection([self.feature1])
+
+        fc.insert(0, self.feature2)
+
+        assert len(fc["features"]) == 2
+        assert fc["features"][1] == self.feature1
+        assert fc["features"][0] == self.feature2

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -59,13 +59,6 @@ class FeatureCollectionTest(unittest.TestCase):
         assert fc["features"][0] == self.feature1
         assert fc["features"][1] == self.feature2
 
-    def test_feature_collection_clear(self):
-        fc = FeatureCollection([self.feature1, self.feature2])
-
-        fc.clear()
-
-        assert not fc["features"]
-
     def test_feature_collection_extend(self):
         fc1 = FeatureCollection([self.feature1])
         fc2 = FeatureCollection([self.feature2])


### PR DESCRIPTION
Implements support for the + operator to `FeatureCollections`, as well as the `clear()`, `append()`, `extend()`, and `insert()` methods

Closes #154 

### To do:
- [ ] Update documentation 
- [ ] Determine right-side addition behavior

### Right side addition

How should right-side addition to generic `Collection` be handled?

When doing something like `FeatureCollection([feature1]) + [feature2]`, it makes sense to me that a `FeatureCollection` would be returned. But what about the reverse, `[feature1] + FeatureCollection([feature2])`? As of right now, a `list` will be returned, but maybe that's not very Pythonic behavior? Should a `TypeError` be raised instead?