### PR TITLE
Test Python 3.10 release candidate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 6
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ def test_suite():
 
 
 major_version, minor_version = sys.version_info[:2]
-if not (major_version == 3 and 6 <= minor_version <= 9):
-    sys.stderr.write("Sorry, only Python 3.6 - 3.9 are "
+if not (major_version == 3 and 6 <= minor_version <= 10):
+    sys.stderr.write("Sorry, only Python 3.6 - 3.10 are "
                      "supported at this time.\n")
     exit(1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,39}, pypy3
+envlist = py{36,37,38,39,310}, pypy3
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
Python 3.10.0 final is due for release in October:

* https://www.python.org/dev/peps/pep-0619/

The first release candidate is now out and the Python release team has issued a call to action for community members:

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.10 compatibilities during this phase. As always, report any issues to the Python bug tracker.

https://discuss.python.org/t/python-3-10-0rc1-is-now-available/9982?u=hugovk

So let's also test 3.10 on the CI. The good news is everything passes.

---

I didn't yet add 3.10 to `python_requires`, `classifiers` or `README.rst`, that can wait until 3.10 is released and officially supported, but could be updated now if you wish.