### PR TITLE
Update README - point winding convention

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,15 +118,15 @@ Polygon
   >>> from geojson import Polygon
 
   >>> # no hole within polygon
-  >>> Polygon([[(2.38, 57.322), (23.194, -20.28), (-120.43, 19.15), (2.38, 57.322)]])  # doctest: +ELLIPSIS
-  {"coordinates": [[[2.3..., 57.32...], [23.19..., -20.2...], [-120.4..., 19.1...]]], "type": "Polygon"}
+  >>> Polygon([[(2.38, 57.322), (-120.43, 19.15), (23.194, -20.28), , (2.38, 57.322)]])  # doctest: +ELLIPSIS
+  {"coordinates": [[[2.3..., 57.32...], [-120.4..., 19.1...], [23.19..., -20.2...]]], "type": "Polygon"}
 
   >>> # hole within polygon
   >>> Polygon([
-  ...     [(2.38, 57.322), (23.194, -20.28), (-120.43, 19.15), (2.38, 57.322)],
+  ...     [(2.38, 57.322), (-120.43, 19.15), (23.194, -20.28), (2.38, 57.322)],
   ...     [(-5.21, 23.51), (15.21, -10.81), (-20.51, 1.51), (-5.21, 23.51)]
   ... ])  # doctest: +ELLIPSIS
-  {"coordinates": [[[2.3..., 57.32...], [23.19..., -20.2...], [-120.4..., 19.1...]], [[-5.2..., 23.5...], [15.2..., -10.8...], [-20.5..., 1.5...], [-5.2..., 23.5...]]], "type": "Polygon"}
+  {"coordinates": [[[2.3..., 57.32...], [-120.4..., 19.1...], [23.19..., -20.2...]], [[-5.2..., 23.5...], [15.2..., -10.8...], [-20.5..., 1.5...], [-5.2..., 23.5...]]], "type": "Polygon"}
 
 Visualize the results of the example above `here <https://gist.github.com/frewsxcv/b2f5c31c10e399a63679>`__. General information about Polygon can be found in `Section 3.1.6`_ and `Appendix A: Polygons`_ within `The GeoJSON Format Specification`_.
 


### PR DESCRIPTION
The original polygon does not respect the geojson convention (2016) for point windings --> right hand rule. 
I did not check other geometries though. 
Best regards,