### PR TITLE
geometry module level default precision control

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,25 @@ coordinates to 6 decimal places (roughly 0.1 meters) by default and can be custo
   >>> Point((-115.12341234, 37.12341234), precision=8)  # rounded to 8 decimal places
   {"coordinates": [-115.12341234, 37.12341234], "type": "Point"}
 
+
+Precision can be set at the package level by setting `geojson.geometry.DEFAULT_PRECISION` 
+
+
+.. code:: python
+
+  >>> import geojson
+
+  >>> geojson.geometry.DEFAULT_PRECISION = 5
+
+  >>> from geojson import Point
+
+  >>> Point((-115.12341234, 37.12341234))  # rounded to 8 decimal places
+  {"coordinates": [-115.12341, 37.12341], "type": "Point"}
+
+
+After setting the DEFAULT_PRECISION, `geojson.load` and `geojson.loads` will round of the coordinates. geosjson
+files can then be simplified by simply dumping the contents using `geojson.dump`
+
 Helpful utilities
 -----------------
 

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -4,12 +4,15 @@ from numbers import Number
 from geojson.base import GeoJSON
 
 
+DEFAULT_PRECISION = 6
+
+
 class Geometry(GeoJSON):
     """
     Represents an abstract base class for a WGS84 geometry.
     """
 
-    def __init__(self, coordinates=None, validate=False, precision=6, **extra):
+    def __init__(self, coordinates=None, validate=False, precision=None, **extra):
         """
         Initialises a Geometry object.
 
@@ -21,6 +24,8 @@ class Geometry(GeoJSON):
         :type precision: integer
         """
         super().__init__(**extra)
+        if precision is None:
+            precision = DEFAULT_PRECISION
         self["coordinates"] = self.clean_coordinates(
             coordinates or [], precision)
 


### PR DESCRIPTION
Authored by @rogerlew , with their permission I am submitting as a pull request.

Resolves #135 

This allows projects to set the default precision that they need, in such a way that it works with `geojson.base.GeoJSON.to_instance` (i.e. when parsing a large JSON tree of objects using factories, without calling individual constructors.)

IQGeo is submitting this pull request because we are unable to upgrade beyond 2.4 without this fix.