### PR TITLE
Allow NULL properties on GeoJSON features

### DIFF
--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -28,7 +28,7 @@ class Feature(GeoJSON):
             self["id"] = id
         self["geometry"] = (self.to_instance(geometry, strict=True)
                             if geometry else None)
-        self["properties"] = properties or {}
+        self["properties"] = properties or {} or None
 
     def errors(self):
         geo = self.get('geometry')


### PR DESCRIPTION
This is regarding the [Issue](https://github.com/jazzband/geojson/issues/179)

Fix is to allow `null` for the GeoJSON Feature `properties` tag ([GeoJSON Spec](https://geojson.org/geojson-spec.html#feature-objects))
```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "geometry": {
        "coordinates": [
          180,
          90
        ],
        "type": "Point"
      },
      "type": "Feature",
      "properties": null
    }
  ]
}
```