### PR TITLE
Implement tox-gh-actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,10 @@ jobs:
         python -m pip install --upgrade codecov tox tox-gh-actions
 
     - name: Tests
-      run: tox
+      run: |
+        coverage run --branch --source=geojson setup.py test
+        coverage xml
+        tox
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,8 @@ jobs:
 
     - name: Tests
       run: |
-        coverage run --branch --source=geojson setup.py test
+        coverage run --branch --source=geojson tox
         coverage xml
-        tox
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade codecov
+        python -m pip install --upgrade codecov tox tox-gh-actions
 
     - name: Tests
-      run: |
-        coverage run --branch --source=geojson setup.py test
-        coverage xml
+      run: tox
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def test_suite():
 
 
 major_version, minor_version = sys.version_info[:2]
-if not (major_version == 3 and 6 <= minor_version <= 10):
+if not (major_version == 3 and 6 <= minor_version < 11):
     sys.stderr.write("Sorry, only Python 3.6 - 3.10 are "
                      "supported at this time.\n")
     exit(1)
@@ -48,7 +48,7 @@ setup(
     package_data={"geojson": ["*.rst"]},
     install_requires=[],
     test_suite="setup.test_suite",
-    python_requires=">=3.6, <=3.10",
+    python_requires=">=3.6, <3.11",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,39,310}, pypy3
+envlist = py{36,37,38,39,310}, pypy-39
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,11 @@ envlist = py{36,37,38,39,310}, pypy-39
 
 [testenv]
 commands = {envpython} setup.py test
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39, pypy-39
+    3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,39,310}, pypy-39
+envlist = py{36,37,38,39,310}, pypy39
 
 [testenv]
 commands = {envpython} setup.py test
@@ -14,5 +14,6 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, pypy-39
+    3.9: py39
     3.10: py310
+    pypy-3.9: pypy39


### PR DESCRIPTION
Implement tox-gh-actions for more robust CI testing as per recommendations at https://jazzband.co/about/releases#continuous-integration

- also bump unit test pypy version to 3.9