### PR TITLE
Change made to handle all real numbers as coordinates #173

### DIFF
--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from numbers import Number
+from numbers import Number, Real
 
 from geojson.base import GeoJSON
 
@@ -47,7 +47,7 @@ class Geometry(GeoJSON):
                 new_coords.append(cls.clean_coordinates(coord, precision))
             elif isinstance(coord, Geometry):
                 new_coords.append(coord['coordinates'])
-            elif isinstance(coord, (float, int, Decimal)):
+            elif isinstance(coord, (Real, Decimal)):
                 new_coords.append(round(coord, precision))
             else:
                 raise ValueError("%r is not a JSON compliant number" % coord)


### PR DESCRIPTION
Changes made per discussion in #173. Suggestions were made to handle all real numbers as inputs, rather than the original `float, int, Decimal` types only. While the original type-check works for a majority of cases, there are users who may try to create geojson objects from objects that are not inherited from the python base-classes listed above. A more generic solution was to type-check against the abstract `Numbers` class, which has a nicely laid out hierarchy per PEP 3141. 