### PR TITLE
Stop building universal wheel because Python 2 is no longer supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
While preparing to release GeoJSON 3.0.0 it became apparent that a Python-2-compatible wheel was still being generated by the CI release tool. This removes the config that caused that behavior.