### PR TITLE
setup.py: Allow Python 3.11 patch versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     package_data={"geojson": ["*.rst"]},
     install_requires=[],
     test_suite="setup.test_suite",
-    python_requires=">=3.7, <=3.11",
+    python_requires=">=3.7, <3.12",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The upper bound in python_requires "<=3.11" excludes patch versions of Python 3.11, as, e.g., Python 3.11.1.

> ERROR: Package 'geojson' requires a different Python: 3.11.1 not in '<=3.11,>=3.7'

By switching from an inclusive to an exclusive upper bound of 3.12, geojson can now be used with all Python 3.11 versions.