### PR TITLE
Type annotation implementation

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright © 2007-2019, contributors of geojson
+Copyright © 2007-2023, contributors of geojson
 
 All rights reserved.
 

--- a/geojson/__init__.py
+++ b/geojson/__init__.py
@@ -7,11 +7,24 @@ from geojson.feature import Feature, FeatureCollection
 from geojson.base import GeoJSON
 from geojson._version import __version__, __version_info__
 
-__all__ = ([dump, dumps, load, loads, GeoJSONEncoder] +
-           [coords, map_coords] +
-           [Point, LineString, Polygon] +
-           [MultiLineString, MultiPoint, MultiPolygon] +
-           [GeometryCollection] +
-           [Feature, FeatureCollection] +
-           [GeoJSON] +
-           [__version__, __version_info__])
+__all__ = (
+    "dump",
+    "dumps",
+    "load",
+    "loads",
+    "GeoJSONEncoder",
+    "coords",
+    "map_coords",
+    "Point",
+    "LineString",
+    "Polygon",
+    "MultiLineString",
+    "MultiPoint",
+    "MultiPolygon",
+    "GeometryCollection",
+    "Feature",
+    "FeatureCollection",
+    "GeoJSON",
+    "__version__",
+    "__version_info__",
+)

--- a/geojson/codec.py
+++ b/geojson/codec.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 try:
     import simplejson as json
 except ImportError:
     import json
 
-import geojson
+from typing import TYPE_CHECKING, IO, Any, Callable, Type
+
 import geojson.factory
 from geojson.mapping import to_mapping
 
+if TYPE_CHECKING:
+    from geojson.types import G
+
 
 class GeoJSONEncoder(json.JSONEncoder):
-
-    def default(self, obj):
+    def default(self, obj: G) -> G:
         return geojson.factory.GeoJSON.to_instance(obj) # NOQA
 
 
@@ -18,36 +23,53 @@ class GeoJSONEncoder(json.JSONEncoder):
 # object creation hooks.
 # Here the defaults are set to only permit valid JSON as per RFC 4267
 
-def _enforce_strict_numbers(obj):
+def _enforce_strict_numbers(obj: str) -> None:
     raise ValueError("Number %r is not JSON compliant" % obj)
 
 
-def dump(obj, fp, cls=GeoJSONEncoder, allow_nan=False, **kwargs):
+def dump(
+    obj: G,
+    fp: IO[str],
+    cls: Type[json.JSONEncoder] = GeoJSONEncoder,
+    allow_nan: bool = False,
+    **kwargs
+) -> None:
     return json.dump(to_mapping(obj),
                      fp, cls=cls, allow_nan=allow_nan, **kwargs)
 
 
-def dumps(obj, cls=GeoJSONEncoder, allow_nan=False, ensure_ascii=False, **kwargs):
-    return json.dumps(to_mapping(obj),
-                      cls=cls, allow_nan=allow_nan, ensure_ascii=ensure_ascii, **kwargs)
+def dumps(
+    obj: G,
+    cls: Type[json.JSONEncoder] = GeoJSONEncoder,
+    allow_nan: bool = False,
+    ensure_ascii: bool = False,
+    **kwargs
+) -> str:
+    return json.dumps(
+        to_mapping(obj),
+        cls=cls,
+        allow_nan=allow_nan,
+        ensure_ascii=ensure_ascii,
+        **kwargs
+    )
 
 
-def load(fp,
-         cls=json.JSONDecoder,
-         parse_constant=_enforce_strict_numbers,
-         object_hook=geojson.base.GeoJSON.to_instance,
-         **kwargs):
+def load(fp: IO[str],
+         cls: Type[json.JSONDecoder] = json.JSONDecoder,
+         parse_constant: Callable[[str], None] = _enforce_strict_numbers,
+         object_hook: Callable[..., G] = geojson.factory.GeoJSON.to_instance,
+         **kwargs) -> Any:
     return json.load(fp,
                      cls=cls, object_hook=object_hook,
                      parse_constant=parse_constant,
                      **kwargs)
 
 
-def loads(s,
-          cls=json.JSONDecoder,
-          parse_constant=_enforce_strict_numbers,
-          object_hook=geojson.base.GeoJSON.to_instance,
-          **kwargs):
+def loads(s: str,
+          cls: Type[json.JSONDecoder] = json.JSONDecoder,
+          parse_constant: Callable[[str], None] = _enforce_strict_numbers,
+          object_hook: Callable[..., G] = geojson.factory.GeoJSON.to_instance,
+          **kwargs) -> Any:
     return json.loads(s,
                       cls=cls, object_hook=object_hook,
                       parse_constant=parse_constant,

--- a/geojson/examples.py
+++ b/geojson/examples.py
@@ -1,11 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, MutableMapping, Optional, Union
+
+if TYPE_CHECKING:
+    from geojson.geometry import Geometry
+    from geojson.types import G
+
+
 class SimpleWebFeature:
 
     """
     A simple, Atom-ish, single geometry (WGS84) GIS feature.
     """
 
-    def __init__(self, id=None, geometry=None, title=None, summary=None,
-                 link=None):
+    def __init__(
+        self,
+        id: Optional[Any] = None,
+        geometry: Union[Geometry, MutableMapping, None] = None,
+        title: Optional[str] = None,
+        summary: Optional[str] = None,
+        link: Optional[str] = None,
+    ) -> None:
         """
         Initialises a SimpleWebFeature from the parameters provided.
 
@@ -19,14 +34,12 @@ class SimpleWebFeature:
         :type summary: str
         :param link: Link associated with the object.
         :type link: str
-        :return: A SimpleWebFeature object
-        :rtype: SimpleWebFeature
         """
         self.id = id
         self.geometry = geometry
         self.properties = {'title': title, 'summary': summary, 'link': link}
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, Any]:
         return {
             "type": "Feature",
             "id": self.id,
@@ -43,7 +56,7 @@ class SimpleWebFeature:
     """
 
 
-def create_simple_web_feature(o):
+def create_simple_web_feature(o: G) -> Union[SimpleWebFeature, G]:
     """
     Create an instance of SimpleWebFeature from a dict, o. If o does not
     match a Python feature object, simply return o. This function serves as a

--- a/geojson/factory.py
+++ b/geojson/factory.py
@@ -4,8 +4,15 @@ from geojson.geometry import GeometryCollection
 from geojson.feature import Feature, FeatureCollection
 from geojson.base import GeoJSON
 
-__all__ = ([Point, LineString, Polygon] +
-           [MultiLineString, MultiPoint, MultiPolygon] +
-           [GeometryCollection] +
-           [Feature, FeatureCollection] +
-           [GeoJSON])
+__all__ = (
+    "Point",
+    "LineString",
+    "Polygon",
+    "MultiLineString",
+    "MultiPoint",
+    "MultiPolygon",
+    "GeometryCollection",
+    "Feature",
+    "FeatureCollection",
+    "GeoJSON",
+)

--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -2,8 +2,15 @@
 SimpleWebFeature is a working example of a class that satisfies the Python geo
 interface.
 """
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from geojson.base import GeoJSON
+
+if TYPE_CHECKING:
+    from geojson.geometry import Geometry
+    from geojson.types import ErrorList, ErrorSingle
 
 
 class Feature(GeoJSON):
@@ -11,7 +18,13 @@ class Feature(GeoJSON):
     Represents a WGS84 GIS feature.
     """
 
-    def __init__(self, id=None, geometry=None, properties=None, **extra):
+    def __init__(
+        self,
+        id: Optional[Any] = None,
+        geometry: Optional[Geometry] = None,
+        properties: Optional[Dict[str, Any]] = None,
+        **extra
+    ) -> None:
         """
         Initialises a Feature object with the given parameters.
 
@@ -20,8 +33,6 @@ class Feature(GeoJSON):
         :param geometry: Geometry corresponding to the feature.
         :param properties: Dict containing properties of the feature.
         :type properties: dict
-        :return: Feature object
-        :rtype: Feature
         """
         super().__init__(**extra)
         if id is not None:
@@ -30,8 +41,8 @@ class Feature(GeoJSON):
                             if geometry else None)
         self["properties"] = properties or {}
 
-    def errors(self):
-        geo = self.get('geometry')
+    def errors(self) -> Union[ErrorSingle, ErrorList]:
+        geo: Optional[Geometry] = self.get('geometry')
         return geo.errors() if geo else None
 
 
@@ -40,21 +51,19 @@ class FeatureCollection(GeoJSON):
     Represents a FeatureCollection, a set of multiple Feature objects.
     """
 
-    def __init__(self, features, **extra):
+    def __init__(self, features: List[Feature], **extra) -> None:
         """
         Initialises a FeatureCollection object from the
         :param features: List of features to constitute the FeatureCollection.
         :type features: list
-        :return: FeatureCollection object
-        :rtype: FeatureCollection
         """
         super().__init__(**extra)
         self["features"] = features
 
-    def errors(self):
+    def errors(self) -> ErrorList:
         return self.check_list_errors(lambda x: x.errors(), self.features)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         try:
             return self.get("features", ())[key]
         except (KeyError, TypeError, IndexError):

--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -1,7 +1,19 @@
+from __future__ import annotations
+
 from decimal import Decimal
-from numbers import Number, Real
+from numbers import Real
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from geojson.base import GeoJSON
+
+if TYPE_CHECKING:
+    from geojson.types import (
+        CoordsAny,
+        PointLike,
+        LineLike,
+        ErrorList,
+        ErrorSingle,
+    )
 
 
 DEFAULT_PRECISION = 6
@@ -12,7 +24,13 @@ class Geometry(GeoJSON):
     Represents an abstract base class for a WGS84 geometry.
     """
 
-    def __init__(self, coordinates=None, validate=False, precision=None, **extra):
+    def __init__(
+        self,
+        coordinates: Optional[CoordsAny] = None,
+        validate: bool = False,
+        precision: Optional[int] = None,
+        **extra
+    ) -> None:
         """
         Initialises a Geometry object.
 
@@ -35,11 +53,10 @@ class Geometry(GeoJSON):
                 raise ValueError(f'{errors}: {coordinates}')
 
     @classmethod
-    def clean_coordinates(cls, coords, precision):
+    def clean_coordinates(cls, coords: CoordsAny, precision: int) -> CoordsAny:
         if isinstance(coords, cls):
             return coords['coordinates']
-
-        new_coords = []
+        new_coords: List[CoordsAny] = []
         if isinstance(coords, Geometry):
             coords = [coords]
         for coord in coords:
@@ -59,15 +76,17 @@ class GeometryCollection(GeoJSON):
     Represents an abstract base class for collections of WGS84 geometries.
     """
 
-    def __init__(self, geometries=None, **extra):
+    def __init__(
+        self, geometries: Optional[List[Geometry]] = None, **extra
+    ) -> None:
         super().__init__(**extra)
         self["geometries"] = geometries or []
 
-    def errors(self):
+    def errors(self) -> List[str]:
         errors = [geom.errors() for geom in self['geometries']]
         return [err for err in errors if err]
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         try:
             return self.get("geometries", ())[key]
         except (KeyError, TypeError, IndexError):
@@ -76,27 +95,28 @@ class GeometryCollection(GeoJSON):
 
 # Marker classes.
 
-def check_point(coord):
+def check_point(coord: PointLike) -> ErrorSingle:
     if not isinstance(coord, list):
         return 'each position must be a list'
     if len(coord) not in (2, 3):
         return 'a position must have exactly 2 or 3 values'
     for number in coord:
-        if not isinstance(number, Number):
+        if not isinstance(number, (Real, Decimal)):
             return 'a position cannot have inner positions'
+    return None
 
 
 class Point(Geometry):
-    def errors(self):
+    def errors(self) -> ErrorSingle:
         return check_point(self['coordinates'])
 
 
 class MultiPoint(Geometry):
-    def errors(self):
+    def errors(self) -> ErrorList:
         return self.check_list_errors(check_point, self['coordinates'])
 
 
-def check_line_string(coord):
+def check_line_string(coord: LineLike) -> ErrorSingle:
     if not isinstance(coord, list):
         return 'each line must be a list of positions'
     if len(coord) < 2:
@@ -106,19 +126,21 @@ def check_line_string(coord):
         error = check_point(pos)
         if error:
             return error
+    return None
 
 
 class LineString(MultiPoint):
-    def errors(self):
-        return check_line_string(self['coordinates'])
+    def errors(self) -> ErrorList:
+        error = check_line_string(self['coordinates'])
+        return [error] if error else []
 
 
 class MultiLineString(Geometry):
-    def errors(self):
+    def errors(self) -> ErrorList:
         return self.check_list_errors(check_line_string, self['coordinates'])
 
 
-def check_polygon(coord):
+def check_polygon(coord: LineLike) -> ErrorSingle:
     if not isinstance(coord, list):
         return 'Each polygon must be a list of linear rings'
 
@@ -133,14 +155,16 @@ def check_polygon(coord):
     if isring is False:
         return 'Each linear ring must end where it started'
 
+    return None
+
 
 class Polygon(Geometry):
-    def errors(self):
+    def errors(self) -> ErrorSingle:
         return check_polygon(self['coordinates'])
 
 
 class MultiPolygon(Geometry):
-    def errors(self):
+    def errors(self) -> ErrorList:
         return self.check_list_errors(check_polygon, self['coordinates'])
 
 

--- a/geojson/mapping.py
+++ b/geojson/mapping.py
@@ -1,19 +1,24 @@
-from collections.abc import MutableMapping
+from __future__ import annotations
 
 try:
     import simplejson as json
 except ImportError:
     import json
 
-import geojson
+from typing import TYPE_CHECKING, Any, Optional, Union, MutableMapping
+
+if TYPE_CHECKING:
+    from geojson.base import GeoJSON
+    from geojson.types import G
 
 
 GEO_INTERFACE_MARKER = "__geo_interface__"
 
 
-def is_mapping(obj):
+def is_mapping(obj: Any) -> bool:
     """
     Checks if the object is an instance of MutableMapping.
+    Exists for backwards compatibility only.
 
     :param obj: Object to be checked.
     :return: Truth value of whether the object is an instance of
@@ -23,17 +28,24 @@ def is_mapping(obj):
     return isinstance(obj, MutableMapping)
 
 
-def to_mapping(obj):
+def to_mapping(obj: Union[G, str]) -> G:
+    """
+    Converts an object to a GeoJSON-like object.
 
-    mapping = getattr(obj, GEO_INTERFACE_MARKER, None)
+    :param obj: A GeoJSON-like object, or a JSON string.
+    :type obj: GeoJSON-like object, str
+    :return: A dictionary-like object representing the input GeoJSON.
+    :rtype: GeoJSON-like object
+    """
+    mapping: Optional[GeoJSON] = getattr(obj, GEO_INTERFACE_MARKER, None)
 
     if mapping is not None:
         return mapping
 
-    if is_mapping(obj):
+    if isinstance(obj, MutableMapping):
         return obj
 
-    if isinstance(obj, geojson.GeoJSON):
-        return dict(obj)
+    if isinstance(obj, str):
+        return json.loads(obj)
 
     return json.loads(json.dumps(obj))

--- a/geojson/types.py
+++ b/geojson/types.py
@@ -1,0 +1,37 @@
+from decimal import Decimal
+from numbers import Real
+from typing import (
+    Callable,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    TypeAlias,
+    TypeVar,
+    Union,
+)
+
+from geojson.base import GeoJSON
+
+# Python 3.7 doesn't support using isinstance() with Protocols
+# Use checks for (Real, Decimal) instead
+SupportsRound: TypeAlias = Union[Real, Decimal]
+
+# Annotation for GeoJSON-like objects
+# Multiple types used, because mutable collections are invariant
+G = TypeVar('G', MutableMapping, dict, GeoJSON)
+
+# Annotations for list-like containers (not GeoJSON instances)
+PointLike: TypeAlias = Union[List[SupportsRound], Tuple[SupportsRound, ...]]
+LineLike: TypeAlias = List[PointLike]
+PolyLike: TypeAlias = List[LineLike]
+MultiPolyLike: TypeAlias = List[PolyLike]
+CoordsAny: TypeAlias = Union[
+    PointLike, LineLike, PolyLike, MultiPolyLike, G, List[G]
+]
+
+# Annotations for GeoJSON validations
+CheckValue = TypeVar('CheckValue', PointLike, LineLike)
+ErrorSingle: TypeAlias = Optional[str]
+ErrorList: TypeAlias = List[ErrorSingle]
+CheckErrorFunc: TypeAlias = Callable[[CheckValue], ErrorSingle]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ with open(VERSIONFILE_PATH) as version_file:
     if mo:
         verstr = mo.group(1)
     else:
-        raise RuntimeError(f"Unable to find version string in {VERSIONFILE_PATH}.")
+        raise RuntimeError(
+            f"Unable to find version string in {VERSIONFILE_PATH}."
+        )
 
 
 def test_suite():
@@ -28,8 +30,9 @@ def test_suite():
 
 major_version, minor_version = sys.version_info[:2]
 if not (major_version == 3 and 7 <= minor_version <= 11):
-    sys.stderr.write("Sorry, only Python 3.7 - 3.11 are "
-                     "supported at this time.\n")
+    sys.stderr.write(
+        "Sorry, only Python 3.7 - 3.11 are " "supported at this time.\n"
+    )
     exit(1)
 
 setup(
@@ -64,5 +67,5 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: GIS",
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,15 @@ import re
 with open("README.rst") as readme_file:
     readme_text = readme_file.read()
 
-VERSIONFILE = "geojson/_version.py"
-verstrline = open(VERSIONFILE).read()
-VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
-mo = re.search(VSRE, verstrline, re.M)
-if mo:
-    verstr = mo.group(1)
-else:
-    raise RuntimeError(f"Unable to find version string in {VERSIONFILE}.")
+VERSIONFILE_PATH = "geojson/_version.py"
+with open(VERSIONFILE_PATH) as version_file:
+    verstrline = version_file.read()
+    VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+    mo = re.search(VSRE, verstrline, re.M)
+    if mo:
+        verstr = mo.group(1)
+    else:
+        raise RuntimeError(f"Unable to find version string in {VERSIONFILE_PATH}.")
 
 
 def test_suite():

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# Tox (https://tox.wiki/) is a tool for running tests in multiple virtualenvs.
+# This configuration file will run the test suite on all supported python
+# versions. To use it install tox with `pip install tox` and then run `tox`
+# from this directory.
 
 [tox]
-envlist = py{36,37,38,39,310}, pypy3
+envlist = py{37,38,39,310,311}, pypy3
 
 [testenv]
+description = Run unittests and doctests
+skip_install = true
 commands = {envpython} setup.py test


### PR DESCRIPTION
Initially, my plan was to add features that I needed in my project. However, upon opening the source code, I realized that it was difficult to understand due to the lack of type annotations. Consequently, I decided to focus on adding type annotations to the codebase. While I am not very proficient in refactoring an existing library, **I hope that you can provide me with advice on how to improve my commits or even take on the task yourself.**

For this task, I used MyPy as a static type checker, which helped me ensure consistency in my annotations. Although I did not intend to refactor the codebase while adding type annotations, there were a few instances where I had to do so to resolve MyPy errors.

In addition to adding type annotations, I also created a new .py file containing all the type variables and aliases. I primarily used type aliases instead of custom types because refactoring to use new custom types would be more complex and dramatic. However, I believe it would be beneficial to consider this approach in the future.

I also made some minor changes to comments and support files.

I am confident that my refactoring did not impact any library functions. All tests passed on Python versions 3.7 through 3.11, as well as in PyPy3. Unfortunately, certain features cannot be implemented due to the need to support Python 3.7, which does not support Literals and isinstance() for Protocols. 

P.S. MyPy and Flake8 checks also passed.