### PR TITLE
Setup flake8 CI job

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,5 +13,10 @@ repos:
     hooks:
       - id: tox-ini-fmt
 
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+
 ci:
   autoupdate_schedule: quarterly

--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -209,11 +209,11 @@ def generate_random(featureType, numberVertices=3,
         return Polygon([points])
 
     def clip(x, min, max):
-        if(min > max):
+        if min > max:
             return x
-        elif(x < min):
+        elif x < min:
             return min
-        elif(x > max):
+        elif x > max:
             return max
         else:
             return x


### PR DESCRIPTION
Summary:
- Fix flake8 errors
```
$ flake8 .
geojson/codec.py:30:80: E501 line too long (82 > 79 characters)
geojson/codec.py:32:80: E501 line too long (88 > 79 characters)
geojson/geometry.py:15:80: E501 line too long (82 > 79 characters)
geojson/utils.py:212:11: E275 missing whitespace after keyword
geojson/utils.py:214:13: E275 missing whitespace after keyword
geojson/utils.py:216:13: E275 missing whitespace after keyword
```
- Setup CI job for flake8