### PR TITLE
Test Python 3.12-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 6
+      max-parallel: 7
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev', 'pypy-3.8']
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ def test_suite():
 
 
 major_version, minor_version = sys.version_info[:2]
-if not (major_version == 3 and 7 <= minor_version <= 11):
-    sys.stderr.write("Sorry, only Python 3.7 - 3.11 are "
+if not (major_version == 3 and 7 <= minor_version <= 12):
+    sys.stderr.write("Sorry, only Python 3.7 - 3.12 are "
                      "supported at this time.\n")
     exit(1)
 
@@ -48,7 +48,7 @@ setup(
     package_data={"geojson": ["*.rst"]},
     install_requires=[],
     test_suite="setup.test_suite",
-    python_requires=">=3.7, <3.12",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,39,310}, pypy3
+envlist = py{py3, 312, 311, 310, 39, 38, 37}
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
Python 3.12 will be in beta in May, which is when third-party projects should start testing it in advance of the October release.

The reason for this is three-fold:

* Find 3.12 incompatibilities in this library and fix them in time
* Find bugs in Python itself, to report them upstream and fix them for everyone
* Allow other libraries that depend on this one, to install and test 3.12