### PR TITLE
Fix tests and don't invoke setup.py directly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 7
+      fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev', 'pypy-3.8']
+        python-version: ['pypy3.9', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
@@ -20,18 +20,18 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
-        cache-dependency-path: setup.py
+        cache-dependency-path: tox.ini
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade coverage
+        python -m pip install --upgrade tox
 
     - name: Tests
       run: |
-        coverage run --branch --source=geojson setup.py test
-        coverage xml
+          tox -e py
 
     - name: Upload coverage
       uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ sdist/
 *.egg-info/
 *.egg
 .tox/
+.coverage
+coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,16 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
+      - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 1.3.0
+    hooks:
+      - id: tox-ini-fmt
 
 ci:
   autoupdate_schedule: quarterly

--- a/README.rst
+++ b/README.rst
@@ -288,7 +288,7 @@ coordinates to 6 decimal places (roughly 0.1 meters) by default and can be custo
   {"coordinates": [-115.12341234, 37.12341234], "type": "Point"}
 
 
-Precision can be set at the package level by setting `geojson.geometry.DEFAULT_PRECISION` 
+Precision can be set at the package level by setting `geojson.geometry.DEFAULT_PRECISION`
 
 
 .. code:: python
@@ -410,7 +410,7 @@ Development
 -----------
 
 To build this project, run :code:`python setup.py build`.
-To run the unit tests, run :code:`python setup.py test`.
+To run the unit tests, run :code:`python -m pip install tox && tox`.
 To run the style checks, run :code:`flake8` (install `flake8` if needed).
 
 Credits

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,6 @@ else:
     raise RuntimeError(f"Unable to find version string in {VERSIONFILE}.")
 
 
-def test_suite():
-    import doctest
-    import unittest
-
-    suite = unittest.TestLoader().discover("tests")
-    suite.addTest(doctest.DocFileSuite("README.rst"))
-    return suite
-
-
 major_version, minor_version = sys.version_info[:2]
 if not (major_version == 3 and 7 <= minor_version <= 12):
     sys.stderr.write("Sorry, only Python 3.7 - 3.12 are "
@@ -47,7 +38,6 @@ setup(
     package_dir={"geojson": "geojson"},
     package_data={"geojson": ["*.rst"]},
     install_requires=[],
-    test_suite="setup.test_suite",
     python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/data.geojson
+++ b/tests/data.geojson
@@ -1,7 +1,7 @@
 {
    "properties": {
       "Ã": "Ã"
-   }, 
+   },
    "type": "Feature",
    "geometry": null
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py{py3, 312, 311, 310, 39, 38, 37}
+requires =
+    tox>=4.2
+env_list =
+    py{py3, 312, 311, 310, 39, 38, 37}
 
 [testenv]
-commands = {envpython} setup.py test
+deps =
+    pytest
+    pytest-cov
+pass_env =
+    FORCE_COLOR
+commands =
+    {envpython} -m pytest --cov geojson --cov tests --cov-report xml {posargs}


### PR DESCRIPTION
The merge of https://github.com/jazzband/geojson/pull/211 failed the CI for Python 3.12:

https://github.com/jazzband/geojson/actions/runs/5098872321/jobs/9166263747

```
Run coverage run --branch --source=geojson setup.py test
Traceback (most recent call last):
  File "/home/runner/work/geojson/geojson/setup.py", line 1, in <module>
    from setuptools import setup
ModuleNotFoundError: No module named 'setuptools'
```

That's because the 3.12 beta removed setuptools from Python. We could install setuptools on the CI, but really we shouldn't be running tests via `python setup.py test` - we shouldn't invoke `setup.py` directly. See https://blog.ganssle.io/tag/setuptools.html for the long version.

Instead, let's modernise testing and use pytest and tox to run the tests.

So for example, tests can be run like:


```
python -m pip install pytest
pytest
```

Or with tox on all available Python versions:

```
python -m pip install tox
tox
```

Or a specific version:

```
tox -e py312
```

Or all in parallel:

```
tox -p auto
```