### PR TITLE
map_tuples() outputs GeoJSON object with identical properties as input GeoJSON object

### DIFF
--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -1,4 +1,7 @@
 """Coordinate utility functions."""
+from .base import GeoJSON
+from typing import Callable
+from copy import deepcopy
 
 
 def coords(obj):
@@ -55,7 +58,7 @@ def map_coords(func, obj):
     return map_tuples(tuple_func, obj)
 
 
-def map_tuples(func, obj):
+def map_tuples(func: Callable, obj: GeoJSON) -> GeoJSON:
     """
     Returns the mapped coordinates from a Geometry after applying the provided
     function to each coordinate.
@@ -88,7 +91,10 @@ def map_tuples(func, obj):
         return map_geometries(lambda g: map_tuples(func, g), obj)
     else:
         raise ValueError("Invalid geometry object %s" % repr(obj))
-    return {'type': obj['type'], 'coordinates': coordinates}
+
+    obj_new = deepcopy(obj)
+    obj_new['coordinates'] = coordinates
+    return obj_new
 
 
 def map_geometries(func, obj):

--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -97,7 +97,7 @@ def map_tuples(func: Callable, obj: GeoJSON) -> GeoJSON:
     return obj_new
 
 
-def map_geometries(func, obj):
+def map_geometries(func: Callable, obj: GeoJSON) -> GeoJSON:
     """
     Returns the result of passing every geometry in the given geojson object
     through func.
@@ -119,19 +119,18 @@ def map_geometries(func, obj):
         'MultiPolygon',
     ]
 
+    obj_new = deepcopy(obj)
     if obj['type'] in simple_types:
         return func(obj)
     elif obj['type'] == 'GeometryCollection':
-        geoms = [func(geom) if geom else None for geom in obj['geometries']]
-        return {'type': obj['type'], 'geometries': geoms}
+        obj_new['geometries'] = [func(geom) if geom else None for geom in obj['geometries']]
     elif obj['type'] == 'Feature':
-        obj['geometry'] = func(obj['geometry']) if obj['geometry'] else None
-        return obj
+        obj_new['geometry'] = func(obj['geometry']) if obj['geometry'] else None
     elif obj['type'] == 'FeatureCollection':
-        feats = [map_geometries(func, feat) for feat in obj['features']]
-        return {'type': obj['type'], 'features': feats}
+        obj_new['features'] = [map_geometries(func, feat) for feat in obj['features']]
     else:
         raise ValueError("Invalid GeoJSON object %s" % repr(obj))
+    return obj_new
 
 
 def generate_random(featureType, numberVertices=3,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import random
 import unittest
 
 import geojson
-from geojson.utils import generate_random, map_geometries
+from geojson.utils import generate_random, map_geometries, map_tuples
 
 
 def generate_bbox():
@@ -97,3 +97,23 @@ class TestMapGeometries(unittest.TestCase):
         invalid_object = geojson.Feature(type="InvalidType")
         with self.assertRaises(ValueError):
             map_geometries(lambda g: g, invalid_object)
+
+
+class TestMapTuples(unittest.TestCase):
+    def test_map_tuples(self):
+        gp_deg = geojson.Point(
+            (-115.81, 37.24),
+            properties={"dogs": 5, "cats": 6, "frogs": 7}
+        )
+        gp_rad = geojson.Point(
+            (-115.81 * 3.14159 / 180.0, 37.24 * 3.14159 / 180.0),
+            properties={"dogs": 5, "cats": 6, "frogs": 7}
+        )
+        gp_rad_mapped = map_tuples(
+            lambda c: (
+                round(c[0] * 3.14159 / 180.0, geojson.geometry.DEFAULT_PRECISION),
+                round(c[1] * 3.14159 / 180.0, geojson.geometry.DEFAULT_PRECISION)
+            ),
+            gp_deg
+        )
+        self.assertEquals(geojson.dumps(gp_rad_mapped), geojson.dumps(gp_rad))


### PR DESCRIPTION
This fixes #136.

Changes applied to utils.map_geometries() and utils.map_tuples():
1. outputs GeoJSON object instead of dictionary
2. outputted GeoJSON object has the same properties as inputted GeoJSON object

A test has been added at test_utils.TestMapTuples().