### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ sdist/
 .tox/
 .coverage
 coverage.xml
+.idea
+.venv*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@ Changes
 =======
 
 
+Unreleased
+----------
+
+- Add support for Python 3.12
+
+
 3.0.1 (2023-02-15)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ This Python library contains:
 Installation
 ------------
 
-geojson is compatible with Python 3.7 - 3.11. The recommended way to install is via pip_:
+geojson is compatible with Python 3.7 - 3.12. The recommended way to install is via pip_:
 
 .. code::
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: GIS",
     ]
 )


### PR DESCRIPTION
Dear @frewsxcv, @rayrrr, and @hugovk,

thanks a stack for conceiving and maintaining the geojson package.

Currently, it is apparently not possible to install the package on Python 3.12 without further ado, see our report at GH-221. This patch intends to improve the situation.

With kind regards,
Andreas.
