### PR TITLE
Don't fail with Python 3.13.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['pypy3.9', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['pypy3.9', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ This Python library contains:
 Installation
 ------------
 
-geojson is compatible with Python 3.7 - 3.12. The recommended way to install is via pip_:
+geojson is compatible with Python 3.7 - 3.13. The recommended way to install is via pip_:
 
 .. code::
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ else:
 
 
 major_version, minor_version = sys.version_info[:2]
-if not (major_version == 3 and 7 <= minor_version <= 12):
-    sys.stderr.write("Sorry, only Python 3.7 - 3.12 are "
+if not (major_version == 3 and 7 <= minor_version <= 13):
+    sys.stderr.write("Sorry, only Python 3.7 - 3.13 are "
                      "supported at this time.\n")
     exit(1)
 
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: GIS",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{py3, 312, 311, 310, 39, 38, 37}
+    py{py3, 313, 312, 311, 310, 39, 38, 37}
 
 [testenv]
 deps =


### PR DESCRIPTION
As reported in [Debian Bug #1082218](https://bugs.debian.org/1082218), `setup.py` fails with Python 3.13.

This is fixed by bumping the upper bound, as the Debian package built fine with 3.13rc2.