### PR TITLE
restore floats (as per RFC 7946 Section 3.1.1)

### DIFF
--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -129,7 +129,7 @@ def map_geometries(func, obj):
 
 
 def generate_random(featureType, numberVertices=3,
-                    boundingBox=[-180, -90, 180, 90]):
+                    boundingBox=[-180.0, -90.0, 180.0, 90.0]):
     """
     Generates random geojson features depending on the parameters
     passed through.
@@ -190,8 +190,8 @@ def generate_random(featureType, numberVertices=3,
             r_i = clip(random.gauss(ave_radius, spikeyness), 0, 2 * ave_radius)
             x = ctr_x + r_i * math.cos(angle)
             y = ctr_y + r_i * math.sin(angle)
-            x = (x + 180) * (abs(lon_min - lon_max) / 360) + lon_min
-            y = (y + 90) * (abs(lat_min - lat_max) / 180) + lat_min
+            x = (x + 180.0) * (abs(lon_min - lon_max) / 360.0) + lon_min
+            y = (y + 90.0) * (abs(lat_min - lat_max) / 180.0) + lat_min
             x = clip(x, lon_min, lon_max)
             y = clip(y, lat_min, lat_max)
             points.append((x, y))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,12 @@ from geojson.utils import generate_random, map_geometries
 
 
 def generate_bbox():
-    min_lat = random.random() * 180 - 90
-    max_lat = random.random() * 180 - 90
+    min_lat = random.random() * 180.0 - 90.0
+    max_lat = random.random() * 180.0 - 90.0
     if min_lat > max_lat:
         min_lat, max_lat = max_lat, min_lat
-    min_lon = random.random() * 360 - 180
-    max_lon = random.random() * 360 - 180
+    min_lon = random.random() * 360.0 - 180.0
+    max_lon = random.random() * 360.0 - 180.0
     if min_lon > max_lon:
         min_lon, max_lon = max_lon, min_lon
     return [min_lon, min_lat, max_lon, max_lat]
@@ -46,7 +46,7 @@ def check_point_bbox(point, bbox):
 class TestGenerateRandom(unittest.TestCase):
     def test_simple_polygon(self):
         for _ in range(5000):
-            bbox = [-180, -90, 180, 90]
+            bbox = [-180.0, -90.0, 180.0, 90.0]
             result = generate_random('Polygon')
             self.assertIsInstance(result, geojson.geometry.Polygon)
             self.assertTrue(geojson.geometry.check_polygon(result))


### PR DESCRIPTION
Follow up to #218. From [RFC 7946 Section 3.1.1](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1) (emphasis added):

> A position is an array of numbers.  There MUST be two or more
   elements.  The first two elements are longitude and latitude, or
   easting and northing, precisely in that order and using _decimal_
   numbers.