### PR TITLE
fix: convert dict features to Feature objects in FeatureCollection

### DIFF
--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -44,7 +44,10 @@ class FeatureCollection(GeoJSON):
         :rtype: FeatureCollection
         """
         super().__init__(**extra)
-        self["features"] = features
+        self["features"] = [
+            self.to_instance(f) if not isinstance(f, GeoJSON) else f
+            for f in features
+        ]
 
     def errors(self):
         return self.check_list_errors(lambda x: x.errors(), self.features)

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -2,8 +2,8 @@ import unittest
 
 import geojson
 
-class FeatureCollectionsTest(unittest.TestCase):
 
+class FeatureCollectionsTest(unittest.TestCase):
     def test_to_instance_converts_nested_features(self):
         """to_instance() should convert dict features to Feature objects in FeatureCollection."""
 

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -6,7 +6,7 @@ class FeatureCollectionsTest(unittest.TestCase):
 
     def test_to_instance_converts_nested_features(self):
         """to_instance() should convert dict features to Feature objects in FeatureCollection."""
-        
+
         feature_collection_dict = {
             "type": "FeatureCollection",
             "features": [

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -1,24 +1,27 @@
+import unittest
 
+import geojson
 
-def test_to_instance_converts_nested_features():
-    """to_instance() should convert dict features to Feature objects in FeatureCollection."""
-    import geojson
+class FeatureCollectionsTest(unittest.TestCase):
 
-    feature_collection_dict = {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {"foo": "bar"},
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+    def test_to_instance_converts_nested_features(self):
+        """to_instance() should convert dict features to Feature objects in FeatureCollection."""
+        
+        feature_collection_dict = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"foo": "bar"},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                    },
                 },
-            },
-        ],
-    }
+            ],
+        }
 
-    obj = geojson.GeoJSON.to_instance(feature_collection_dict)
-    assert isinstance(obj, geojson.FeatureCollection)
-    assert isinstance(obj.features[0], geojson.Feature)
-    assert obj.is_valid
+        obj = geojson.GeoJSON.to_instance(feature_collection_dict)
+        self.assertTrue(isinstance(obj, geojson.FeatureCollection))
+        self.assertTrue(isinstance(obj.features[0], geojson.Feature))
+        self.assertTrue(obj.is_valid)

--- a/tests/test_feature_collection.py
+++ b/tests/test_feature_collection.py
@@ -1,0 +1,24 @@
+
+
+def test_to_instance_converts_nested_features():
+    """to_instance() should convert dict features to Feature objects in FeatureCollection."""
+    import geojson
+
+    feature_collection_dict = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"foo": "bar"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                },
+            },
+        ],
+    }
+
+    obj = geojson.GeoJSON.to_instance(feature_collection_dict)
+    assert isinstance(obj, geojson.FeatureCollection)
+    assert isinstance(obj.features[0], geojson.Feature)
+    assert obj.is_valid


### PR DESCRIPTION
## Problem

When `GeoJSON.to_instance()` is called with a `FeatureCollection` dict, the nested feature dicts are stored as plain `dict` objects instead of being converted to `Feature` GeoJSON objects.

This causes:
- `obj.features[0]` returns a `dict` instead of a `Feature`
- `obj.is_valid` raises `AttributeError`

```python
obj = geojson.GeoJSON.to_instance(feature_collection_dict)
print(type(obj.features[0]))  # <class 'dict'>  ← should be Feature
print(obj.is_valid)           # AttributeError  ← should be True
```

## Fix

Convert each feature in `FeatureCollection.__init__` using `to_instance()` if the feature is not already a `GeoJSON` instance.

## Tests

Added a test covering the `to_instance()` → `FeatureCollection` → nested `Feature` conversion path.

Fixes #236