### PR TITLE
remove support for EOL Python versions and update testing deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['pypy3.9', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['pypy3.10', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -9,12 +9,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.4.1
+    rev: 1.7.1
     hooks:
       - id: tox-ini-fmt
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright © 2007-2019, contributors of geojson
+Copyright © 2007-2026, contributors of geojson
 
 All rights reserved.
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ This Python library contains:
 Installation
 ------------
 
-geojson is compatible with Python 3.7 - 3.13. The recommended way to install is via pip_:
+geojson is compatible with Python 3.10 - 3.13. The recommended way to install is via pip_:
 
 .. code::
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ else:
 
 
 major_version, minor_version = sys.version_info[:2]
-if not (major_version == 3 and 7 <= minor_version <= 13):
-    sys.stderr.write("Sorry, only Python 3.7 - 3.13 are "
+if not (major_version == 3 and 10 <= minor_version <= 13):
+    sys.stderr.write("Sorry, only Python 3.10 - 3.13 are "
                      "supported at this time.\n")
     exit(1)
 
@@ -38,7 +38,7 @@ setup(
     package_dir={"geojson": "geojson"},
     package_data={"geojson": ["*.rst"]},
     install_requires=[],
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -47,9 +47,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 requires =
-    tox>=4.2
+    tox>=4.5
 env_list =
-    py{py3, 313, 312, 311, 310, 39, 38, 37}
+    py{py3, 313, 312, 311, 310}
 
 [testenv]
 deps =


### PR DESCRIPTION
This software supply chain security PR removes support for EOL Python versions (3.7, 3.8, 3.9).

Version 3.2.0 of `geojson` is the last to support these versions. Upgrading to supported versions is highly recommended.

