### PR TITLE
`__all__` must be a sequence of strings: fix `__init__.py` and `factory.py`

### DIFF
--- a/geojson/__init__.py
+++ b/geojson/__init__.py
@@ -7,11 +7,24 @@ from geojson.feature import Feature, FeatureCollection
 from geojson.base import GeoJSON
 from geojson._version import __version__, __version_info__
 
-__all__ = ([dump, dumps, load, loads, GeoJSONEncoder] +
-           [coords, map_coords] +
-           [Point, LineString, Polygon] +
-           [MultiLineString, MultiPoint, MultiPolygon] +
-           [GeometryCollection] +
-           [Feature, FeatureCollection] +
-           [GeoJSON] +
-           [__version__, __version_info__])
+__all__ = [
+    "dump",
+    "dumps",
+    "load",
+    "loads",
+    "GeoJSONEncoder",
+    "coords",
+    "map_coords",
+    "Point",
+    "LineString",
+    "Polygon",
+    "MultiLineString",
+    "MultiPoint",
+    "MultiPolygon",
+    "GeometryCollection",
+    "Feature",
+    "FeatureCollection",
+    "GeoJSON",
+    "__version__",
+    "__version_info__",
+]

--- a/geojson/factory.py
+++ b/geojson/factory.py
@@ -4,8 +4,15 @@ from geojson.geometry import GeometryCollection
 from geojson.feature import Feature, FeatureCollection
 from geojson.base import GeoJSON
 
-__all__ = ([Point, LineString, Polygon] +
-           [MultiLineString, MultiPoint, MultiPolygon] +
-           [GeometryCollection] +
-           [Feature, FeatureCollection] +
-           [GeoJSON])
+__all__ = [
+    "Point",
+    "LineString",
+    "Polygon",
+    "MultiLineString",
+    "MultiPoint",
+    "MultiPolygon",
+    "GeometryCollection",
+    "Feature",
+    "FeatureCollection",
+    "GeoJSON",
+]


### PR DESCRIPTION
See the [documentation](https://docs.python.org/3/reference/simple_stmts.html#module.__all__):

> The *public names* defined by a module are determined by checking the module’s namespace for a variable named `__all__`; if defined, **it must be a sequence of strings** which are names defined or imported by that module.

`pytest ./tests` is passing.
